### PR TITLE
Fix Xbox button parsing

### DIFF
--- a/XboxJoystickTester/MainForm.cs
+++ b/XboxJoystickTester/MainForm.cs
@@ -26,10 +26,11 @@ namespace XboxJoystickTester
             if (XInput.XInputGetState(0, ref _state) == 0)
             {
                 lblConnected.Text = "Connected";
-                lblA.Text = (_state.Gamepad.wButtons & XInput.ButtonFlags.A) != 0 ? "A: Pressed" : "A: Released";
-                lblB.Text = (_state.Gamepad.wButtons & XInput.ButtonFlags.B) != 0 ? "B: Pressed" : "B: Released";
-                lblX.Text = (_state.Gamepad.wButtons & XInput.ButtonFlags.X) != 0 ? "X: Pressed" : "X: Released";
-                lblY.Text = (_state.Gamepad.wButtons & XInput.ButtonFlags.Y) != 0 ? "Y: Pressed" : "Y: Released";
+                var buttons = (XInput.ButtonFlags)_state.Gamepad.wButtons;
+                lblA.Text = (buttons & XInput.ButtonFlags.A) != 0 ? "A: Pressed" : "A: Released";
+                lblB.Text = (buttons & XInput.ButtonFlags.B) != 0 ? "B: Pressed" : "B: Released";
+                lblX.Text = (buttons & XInput.ButtonFlags.X) != 0 ? "X: Pressed" : "X: Released";
+                lblY.Text = (buttons & XInput.ButtonFlags.Y) != 0 ? "Y: Pressed" : "Y: Released";
                 lblLX.Text = $"LX: {_state.Gamepad.sThumbLX}";
                 lblLY.Text = $"LY: {_state.Gamepad.sThumbLY}";
                 lblRX.Text = $"RX: {_state.Gamepad.sThumbRX}";


### PR DESCRIPTION
## Summary
- fix cast when decoding `XINPUT_STATE` buttons

## Testing
- `dotnet build XboxJoystickTester/XboxJoystickTester.csproj -c Release /p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_686352c1f1508328a59b3294a5e8872f