### PR TITLE
Make release zipped portable build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,11 +16,15 @@ jobs:
         with:
           dotnet-version: '6.0.x'
       - name: Publish
-        run: dotnet publish XboxJoystickTester/XboxJoystickTester.csproj -c Release -r win-x64 --self-contained false
+        run: |
+          dotnet publish XboxJoystickTester/XboxJoystickTester.csproj \
+            -c Release -r win-x64 --self-contained true \
+            -o publish
+          Compress-Archive -Path publish/* -DestinationPath XboxJoystickTester.zip
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}-${{ github.run_number }}
           name: Release ${{ github.ref_name }} build ${{ github.run_number }}
-          files: XboxJoystickTester/bin/Release/net6.0-windows/win-x64/publish/XboxJoystickTester.exe
+          files: XboxJoystickTester.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Build artifacts
+bin/
+obj/
+# Visual Studio
+.vs/
+# Publish outputs
+publish/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This repository contains a minimal Windows Forms application for testing Xbox co
 1. Open `XboxJoystickTester.sln` with Visual Studio 2022 or newer on Windows.
 2. Restore NuGet packages if needed.
 3. Build the solution in **Release** mode.
-4. Run or publish to produce an executable `.exe`.
+4. Choose **Publish** to create a self-contained build for `win-x64`. The
+   output will be written to `publish/`. Compress this folder into a `.zip`
+   archive so that anyone can unzip it and run the included executable without
+   installing .NET.
 
 ## Features
 
@@ -19,5 +22,5 @@ The code can be extended to add detailed diagnostics and PDF report generation.
 
 ## Continuous Integration
 
-Pushes to branches starting with `Feature/` automatically trigger a GitHub Actions workflow that builds the project and publishes a `.exe` to the repository Releases.
-The workflow grants write access to the generated release using `permissions: write-all` so that the built executable can be uploaded automatically.
+Pushes to branches starting with `Feature/` automatically trigger a GitHub Actions workflow that builds the project and uploads a `.zip` containing the published files to the repository Releases.
+The workflow grants write access to the generated release using `permissions: write-all` so that the portable archive can be uploaded automatically.

--- a/XboxJoystickTester/XboxJoystickTester.csproj
+++ b/XboxJoystickTester/XboxJoystickTester.csproj
@@ -3,5 +3,8 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <!-- Publish settings for a portable distribution -->
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- update csproj for non-single-file self-contained build
- publish zipped output folder in CI
- document zipped distribution in README

## Testing
- ❌ `dotnet --version` *(command not found)*
- ❌ `dotnet build XboxJoystickTester/XboxJoystickTester.csproj -c Release /p:EnableWindowsTargeting=true` *(dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686356178d2c8328b8e811561ecbe0d6