### PR TITLE
Add analog stick visuals and enlarge UI

### DIFF
--- a/XboxJoystickTester/MainForm.Designer.cs
+++ b/XboxJoystickTester/MainForm.Designer.cs
@@ -25,6 +25,8 @@ namespace XboxJoystickTester
         private System.Windows.Forms.Label lblRB;
         private System.Windows.Forms.Label lblStart;
         private System.Windows.Forms.Label lblBack;
+        private System.Windows.Forms.Panel panelLeftStick;
+        private System.Windows.Forms.Panel panelRightStick;
 
         protected override void Dispose(bool disposing)
         {
@@ -59,6 +61,8 @@ namespace XboxJoystickTester
             this.lblRB = new System.Windows.Forms.Label();
             this.lblStart = new System.Windows.Forms.Label();
             this.lblBack = new System.Windows.Forms.Label();
+            this.panelLeftStick = new System.Windows.Forms.Panel();
+            this.panelRightStick = new System.Windows.Forms.Panel();
             ((System.ComponentModel.ISupportInitialize)(this.trackLeft)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackRight)).BeginInit();
             this.SuspendLayout();
@@ -192,9 +196,9 @@ namespace XboxJoystickTester
             this.lblDPadUp.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.lblDPadUp.Location = new System.Drawing.Point(12, 255);
             this.lblDPadUp.Name = "lblDPadUp";
-            this.lblDPadUp.Size = new System.Drawing.Size(60, 20);
+            this.lblDPadUp.Size = new System.Drawing.Size(80, 35);
             this.lblDPadUp.TabIndex = 14;
-            this.lblDPadUp.Text = "Up";
+            this.lblDPadUp.Text = "D-Pad Up";
             this.lblDPadUp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lblDPadUp.BackColor = System.Drawing.Color.Gray;
             //
@@ -202,11 +206,11 @@ namespace XboxJoystickTester
             //
             this.lblDPadDown.AutoSize = false;
             this.lblDPadDown.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lblDPadDown.Location = new System.Drawing.Point(97, 255);
+            this.lblDPadDown.Location = new System.Drawing.Point(102, 255);
             this.lblDPadDown.Name = "lblDPadDown";
-            this.lblDPadDown.Size = new System.Drawing.Size(60, 20);
+            this.lblDPadDown.Size = new System.Drawing.Size(80, 35);
             this.lblDPadDown.TabIndex = 15;
-            this.lblDPadDown.Text = "Down";
+            this.lblDPadDown.Text = "D-Pad Down";
             this.lblDPadDown.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lblDPadDown.BackColor = System.Drawing.Color.Gray;
             //
@@ -214,11 +218,11 @@ namespace XboxJoystickTester
             //
             this.lblDPadLeft.AutoSize = false;
             this.lblDPadLeft.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lblDPadLeft.Location = new System.Drawing.Point(182, 255);
+            this.lblDPadLeft.Location = new System.Drawing.Point(192, 255);
             this.lblDPadLeft.Name = "lblDPadLeft";
-            this.lblDPadLeft.Size = new System.Drawing.Size(60, 20);
+            this.lblDPadLeft.Size = new System.Drawing.Size(80, 35);
             this.lblDPadLeft.TabIndex = 16;
-            this.lblDPadLeft.Text = "Left";
+            this.lblDPadLeft.Text = "D-Pad Left";
             this.lblDPadLeft.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lblDPadLeft.BackColor = System.Drawing.Color.Gray;
             //
@@ -226,11 +230,11 @@ namespace XboxJoystickTester
             //
             this.lblDPadRight.AutoSize = false;
             this.lblDPadRight.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lblDPadRight.Location = new System.Drawing.Point(267, 255);
+            this.lblDPadRight.Location = new System.Drawing.Point(282, 255);
             this.lblDPadRight.Name = "lblDPadRight";
-            this.lblDPadRight.Size = new System.Drawing.Size(60, 20);
+            this.lblDPadRight.Size = new System.Drawing.Size(80, 35);
             this.lblDPadRight.TabIndex = 17;
-            this.lblDPadRight.Text = "Right";
+            this.lblDPadRight.Text = "D-Pad Right";
             this.lblDPadRight.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lblDPadRight.BackColor = System.Drawing.Color.Gray;
             //
@@ -240,9 +244,9 @@ namespace XboxJoystickTester
             this.lblLB.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.lblLB.Location = new System.Drawing.Point(12, 285);
             this.lblLB.Name = "lblLB";
-            this.lblLB.Size = new System.Drawing.Size(60, 20);
+            this.lblLB.Size = new System.Drawing.Size(120, 35);
             this.lblLB.TabIndex = 18;
-            this.lblLB.Text = "LB";
+            this.lblLB.Text = "Left Bumper";
             this.lblLB.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lblLB.BackColor = System.Drawing.Color.Gray;
             //
@@ -250,11 +254,11 @@ namespace XboxJoystickTester
             //
             this.lblRB.AutoSize = false;
             this.lblRB.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lblRB.Location = new System.Drawing.Point(97, 285);
+            this.lblRB.Location = new System.Drawing.Point(144, 285);
             this.lblRB.Name = "lblRB";
-            this.lblRB.Size = new System.Drawing.Size(60, 20);
+            this.lblRB.Size = new System.Drawing.Size(120, 35);
             this.lblRB.TabIndex = 19;
-            this.lblRB.Text = "RB";
+            this.lblRB.Text = "Right Bumper";
             this.lblRB.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lblRB.BackColor = System.Drawing.Color.Gray;
             //
@@ -262,11 +266,11 @@ namespace XboxJoystickTester
             //
             this.lblStart.AutoSize = false;
             this.lblStart.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lblStart.Location = new System.Drawing.Point(182, 285);
+            this.lblStart.Location = new System.Drawing.Point(276, 285);
             this.lblStart.Name = "lblStart";
-            this.lblStart.Size = new System.Drawing.Size(60, 20);
+            this.lblStart.Size = new System.Drawing.Size(100, 35);
             this.lblStart.TabIndex = 20;
-            this.lblStart.Text = "Start";
+            this.lblStart.Text = "Menu";
             this.lblStart.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lblStart.BackColor = System.Drawing.Color.Gray;
             //
@@ -274,19 +278,36 @@ namespace XboxJoystickTester
             //
             this.lblBack.AutoSize = false;
             this.lblBack.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lblBack.Location = new System.Drawing.Point(267, 285);
+            this.lblBack.Location = new System.Drawing.Point(276, 325);
             this.lblBack.Name = "lblBack";
-            this.lblBack.Size = new System.Drawing.Size(60, 20);
+            this.lblBack.Size = new System.Drawing.Size(100, 35);
             this.lblBack.TabIndex = 21;
-            this.lblBack.Text = "Back";
+            this.lblBack.Text = "View";
             this.lblBack.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lblBack.BackColor = System.Drawing.Color.Gray;
-            // 
+            //
+            // panelLeftStick
+            //
+            this.panelLeftStick.Location = new System.Drawing.Point(380, 30);
+            this.panelLeftStick.Name = "panelLeftStick";
+            this.panelLeftStick.Size = new System.Drawing.Size(180, 180);
+            this.panelLeftStick.TabIndex = 22;
+            this.panelLeftStick.Paint += new System.Windows.Forms.PaintEventHandler(this.panelLeftStick_Paint);
+            //
+            // panelRightStick
+            //
+            this.panelRightStick.Location = new System.Drawing.Point(380, 230);
+            this.panelRightStick.Name = "panelRightStick";
+            this.panelRightStick.Size = new System.Drawing.Size(180, 180);
+            this.panelRightStick.TabIndex = 23;
+            this.panelRightStick.Paint += new System.Windows.Forms.PaintEventHandler(this.panelRightStick_Paint);
+            //
             // MainForm
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(360, 320);
+            this.ClientSize = new System.Drawing.Size(600, 420);
+            this.Font = new System.Drawing.Font("Segoe UI", 14F);
             this.Controls.Add(this.lblBack);
             this.Controls.Add(this.lblStart);
             this.Controls.Add(this.lblRB);
@@ -309,6 +330,8 @@ namespace XboxJoystickTester
             this.Controls.Add(this.lblB);
             this.Controls.Add(this.lblA);
             this.Controls.Add(this.lblConnected);
+            this.Controls.Add(this.panelLeftStick);
+            this.Controls.Add(this.panelRightStick);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
             this.Name = "MainForm";

--- a/XboxJoystickTester/MainForm.cs
+++ b/XboxJoystickTester/MainForm.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Forms;
@@ -10,6 +11,10 @@ namespace XboxJoystickTester
     {
         private Timer _timer;
         private XInput.XINPUT_STATE _state;
+        private float _leftX;
+        private float _leftY;
+        private float _rightX;
+        private float _rightY;
 
         public MainForm()
         {
@@ -35,6 +40,12 @@ namespace XboxJoystickTester
                 lblLY.Text = $"LY: {_state.Gamepad.sThumbLY}";
                 lblRX.Text = $"RX: {_state.Gamepad.sThumbRX}";
                 lblRY.Text = $"RY: {_state.Gamepad.sThumbRY}";
+                _leftX = _state.Gamepad.sThumbLX;
+                _leftY = _state.Gamepad.sThumbLY;
+                _rightX = _state.Gamepad.sThumbRX;
+                _rightY = _state.Gamepad.sThumbRY;
+                panelLeftStick.Invalidate();
+                panelRightStick.Invalidate();
                 progressLT.Value = _state.Gamepad.bLeftTrigger;
                 progressRT.Value = _state.Gamepad.bRightTrigger;
                 var on = Color.Lime;
@@ -53,6 +64,9 @@ namespace XboxJoystickTester
                 lblConnected.Text = "No controller";
                 lblDPadUp.BackColor = lblDPadDown.BackColor = lblDPadLeft.BackColor = lblDPadRight.BackColor =
                     lblLB.BackColor = lblRB.BackColor = lblStart.BackColor = lblBack.BackColor = Color.Gray;
+                _leftX = _leftY = _rightX = _rightY = 0;
+                panelLeftStick.Invalidate();
+                panelRightStick.Invalidate();
             }
         }
 
@@ -62,6 +76,29 @@ namespace XboxJoystickTester
             ushort rightMotor = (ushort)(trackRight.Value * 655);
             var vibration = new XInput.XINPUT_VIBRATION { wLeftMotorSpeed = leftMotor, wRightMotorSpeed = rightMotor };
             XInput.XInputSetState(0, ref vibration);
+        }
+
+        private void panelLeftStick_Paint(object sender, PaintEventArgs e)
+        {
+            DrawStick(e.Graphics, panelLeftStick, _leftX, _leftY);
+        }
+
+        private void panelRightStick_Paint(object sender, PaintEventArgs e)
+        {
+            DrawStick(e.Graphics, panelRightStick, _rightX, _rightY);
+        }
+
+        private void DrawStick(Graphics g, Panel panel, float x, float y)
+        {
+            g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+            int radius = Math.Min(panel.Width, panel.Height) / 2 - 5;
+            int centerX = panel.Width / 2;
+            int centerY = panel.Height / 2;
+            g.DrawEllipse(Pens.Black, centerX - radius, centerY - radius, radius * 2, radius * 2);
+            int ballRadius = 6;
+            int bx = centerX + (int)(x / 32767f * radius);
+            int by = centerY - (int)(y / 32767f * radius);
+            g.FillEllipse(Brushes.Red, bx - ballRadius, by - ballRadius, ballRadius * 2, ballRadius * 2);
         }
     }
 


### PR DESCRIPTION
## Summary
- display analog stick positions in realtime using two new panels
- increase default font size and window dimensions
- rename button labels to official Xbox names

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build XboxJoystickTester.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686422f434dc8328877854af1fab38b6